### PR TITLE
Add AI agents to allowlist

### DIFF
--- a/BOT_ALLOWLIST.md
+++ b/BOT_ALLOWLIST.md
@@ -1,3 +1,5 @@
 webpack[bot]
 cursor[bot]
+cursor
+coderabbitai[bot]
 coderabbitai

--- a/BOT_ALLOWLIST.md
+++ b/BOT_ALLOWLIST.md
@@ -1,1 +1,3 @@
 webpack[bot]
+cursor[bot]
+coderabbitai


### PR DESCRIPTION
cc @webpack/tsc IIUC AI agents should be excluded from the CLA list. They run on behalf of their owner, who must sign the CLA. They themselves cannot sign, and thus, should be excluded.